### PR TITLE
feat: support types for the library being loaded

### DIFF
--- a/src/useLibrary.ts
+++ b/src/useLibrary.ts
@@ -5,8 +5,8 @@ function getFromWindow(varName: string) {
     return (window as unknown as {[k: string]: unknown})[varName]
 }
 
-export function useLibrary(varName: string, src: string, props: { [k in WritableKeys<HTMLScriptElement>]?: HTMLScriptElement[k] } = {})
-    : [library: unknown, status: string, tryAgain: () => void]
+export function useLibrary<T>(varName: string, src: string, props: { [k in WritableKeys<HTMLScriptElement>]?: HTMLScriptElement[k] } = {})
+    : [library: T, status: string, tryAgain: () => void]
 {
     const library = useRef(getFromWindow(varName))
     const [status, setStatus] = useState(library.current ? 'load' : 'try')


### PR DESCRIPTION

**Check**
- [X] This does not introduce breaking changes
- [ ] This contains tests for the newly introduced behavior
- [ ] This contains documentation of the newly introduced behavior

**How**
Added a generic to be used as the library types

**Additional information**
Example

```
const [someLibrary] = useWebLibrary<{something: string}>('$', 'https://example.com/someLibrary');

someLibrary.something -> string
```
